### PR TITLE
Improve test guards for missing dependencies

### DIFF
--- a/tests/audio/test_condenser_contract.py
+++ b/tests/audio/test_condenser_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -11,6 +12,13 @@ import pytest
 SAMPLES_DIR = Path(__file__).resolve().parent / "sample_audio"
 SHORT_FLAC = SAMPLES_DIR / "ASR_Test.flac"
 ARTIFACTS_DIR = Path(__file__).parent / "artifacts"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg is required for condenser contract tests"
+)
+
+if not SHORT_FLAC.exists():
+    pytest.skip("Sample audio fixture missing", allow_module_level=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/audio/test_decoder_contract.py
+++ b/tests/audio/test_decoder_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -12,6 +13,13 @@ import pytest
 SAMPLES_DIR = Path(__file__).resolve().parent / "sample_audio"
 SHORT_FLAC = SAMPLES_DIR / "ASR_Test.flac"
 ARTIFACTS_DIR = Path(__file__).parent / "artifacts"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg is required for decoder contract tests"
+)
+
+if not SHORT_FLAC.exists():
+    pytest.skip("Sample audio fixture missing", allow_module_level=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/audio/test_vad_contract.py
+++ b/tests/audio/test_vad_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -14,6 +15,13 @@ import pytest
 SAMPLES_DIR = Path(__file__).resolve().parent / "sample_audio"
 SHORT_FLAC = SAMPLES_DIR / "ASR_Test.flac"
 ARTIFACTS_DIR = Path(__file__).parent / "artifacts"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg is required for VAD contract tests"
+)
+
+if not SHORT_FLAC.exists():
+    pytest.skip("Sample audio fixture missing", allow_module_level=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/test_check_command.py
+++ b/tests/cli/test_check_command.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -8,6 +9,10 @@ from pathlib import Path
 import pytest
 
 ARTIFACTS_DIR = Path(__file__).parent / "artifacts"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg is required for dependency checks"
+)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Pytest configuration for integration-heavy CLI tests.
+
+This file ensures the project root is on ``PYTHONPATH`` so that
+``python -m vociferous.cli.main`` works when running from the source
+tree without an editable install. The environment modification is
+process-wide and inherited by subprocess-based CLI invocations used
+throughout the test suite.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _ensure_repo_on_path() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    existing = os.environ.get("PYTHONPATH")
+    paths = [str(repo_root)]
+    if existing:
+        paths.append(existing)
+    os.environ["PYTHONPATH"] = ":".join(paths)
+
+
+_ensure_repo_on_path()
+

--- a/tests/engines/test_canary_qwen_contract.py
+++ b/tests/engines/test_canary_qwen_contract.py
@@ -11,6 +11,14 @@ from pathlib import Path
 
 import pytest
 
+torch = pytest.importorskip("torch", reason="Canary tests require PyTorch")
+pytest.importorskip(
+    "nemo.collections.speechlm2.models",
+    reason="Canary-Qwen tests require NeMo dependencies",
+)
+if not torch.cuda.is_available():  # pragma: no cover - hardware guard
+    pytest.skip("Canary tests require CUDA GPU", allow_module_level=True)
+
 from vociferous.domain.model import EngineConfig, TranscriptionOptions
 from vociferous.engines.canary_qwen import CanaryQwenEngine
 

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -3,12 +3,22 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 SAMPLES_DIR = Path(__file__).resolve().parents[1] / "audio" / "sample_audio"
 SHORT_FLAC = SAMPLES_DIR / "ASR_Test.flac"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None, reason="ffmpeg is required for pipeline contract tests"
+)
+
+if not SHORT_FLAC.exists():
+    pytest.skip("Sample audio fixture missing", allow_module_level=True)
 
 
 def _run_cli(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Summary
- ensure pytest subprocess CLI runs can import the package by injecting the repo root into PYTHONPATH
- skip integration and audio contract tests when ffmpeg or sample audio assets are unavailable
- add dependency and hardware guards for Canary-Qwen contract tests to avoid failures when NeMo/CUDA are missing

## Testing
- pytest -q tests/audio/test_decoder_contract.py --disable-warnings


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a889903f0832c9bf21cccdcc59017)